### PR TITLE
Adds faces for type forms

### DIFF
--- a/pine-script-mode.el
+++ b/pine-script-mode.el
@@ -53,6 +53,8 @@
 (defvar pine-script-font-lock-keywords
   `(("$$(\\s *\\w+\\s *)" (0 font-lock-function-name-face t))
     ("$$\\[\\s *\\w+\\s *\\]" (0 font-lock-function-name-face t))
+    (,(concat (regexp-opt '("float" "int" "bool" "string" "color") `words) "[^\.\\|\\(\\|=]")
+        (0 font-lock-type-face))
     (,(regexp-opt '("accdist" "adjustment.dividends" "adjustment.none" "adjustment.splits"
                     "alert.freq_all" "alert.freq_once_per_bar" "alert.freq_once_per_bar_close"
                     "bar_index" "barmerge.gaps_off" "barmerge.gaps_on" "barmerge.lookahead_off"


### PR DESCRIPTION
Example matches using color type form:
`color` red = #800000

Won't match:
color.red
color()
color="red"